### PR TITLE
Reduce SMART_NUM timing to fix Windows Bluetooth layer lag

### DIFF
--- a/config/base.keymap
+++ b/config/base.keymap
@@ -126,9 +126,9 @@ ZMK_ADAPTIVE_KEY(
 // Tap: num-word | double-tap: sticky num-layer | Hold: num-layer.
 #define SMART_NUM &smart_num NUM 0
 ZMK_HOLD_TAP(smart_num, bindings = <&mo>, <&num_dance>; flavor = "balanced";
-             tapping-term-ms = <200>; quick-tap-ms = <QUICK_TAP_MS>;)
+             tapping-term-ms = <150>; quick-tap-ms = <QUICK_TAP_MS>;)
 ZMK_TAP_DANCE(num_dance, bindings = <&num_word NUM>, <&sl NUM>;
-              tapping-term-ms = <200>;)
+              tapping-term-ms = <120>;)
 
 // Smart-mouse, requires tri-state module.
 ZMK_TRI_STATE(


### PR DESCRIPTION
Reduces tapping-term-ms values for num layer activation to improve responsiveness on Windows over Bluetooth:
- smart_num hold-tap: 200ms -> 150ms
- num_dance tap-dance: 200ms -> 120ms

This addresses the compounding delay issue where tap-dance within hold-tap behaviors can create up to 400ms lag before layer activation. The reduced timings maintain functionality while cutting total potential delay to ~270ms, significantly improving perceived responsiveness.

Related to ZMK issue #1691 (tap-dance with layer-tap slow activation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)